### PR TITLE
fix: remove redirect on health endpoint

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -10,7 +10,7 @@ const nextConfig: NextConfig = {
   redirects: async () => {
     return [
       {
-        source: '/((?!signin|signup).*)',
+        source: '/((?!signin|signup|health).*)',
         destination: '/signin',
         permanent: false,
         missing: [


### PR DESCRIPTION
Removes the signin redirect for the health endpoint

## Checklist

- [x] Relevant issue(s) linked (e.g., `Closes #<issue-number>`)
- [x] Follows the [CONTRIBUTING.md](https://github.com/integrasjonsprosjekt/memora/blob/main/CONTRIBUTING.md) guideline
- [x] New functionality tested
- [x] Relevant tests added/updated
- [x] No merge conflicts
- [x] Documentation updated
